### PR TITLE
jQuery lightweight plugin boilerplate

### DIFF
--- a/src/jquery.jSprite.js
+++ b/src/jquery.jSprite.js
@@ -1,27 +1,4 @@
-/*!
- * jQuery lightweight plugin boilerplate
- * Original author: @ajpiano
- * Further changes, comments: @addyosmani
- * Licensed under the MIT license
- */
-
-// the semi-colon before the function invocation is a safety
-// net against concatenated scripts and/or other plugins
-// that are not closed properly.
 ;(function ( $, window, document, undefined ) {
-
-    // undefined is used here as the undefined global
-    // variable in ECMAScript 3 and is mutable (i.e. it can
-    // be changed by someone else). undefined isn't really
-    // being passed in so we can ensure that its value is
-    // truly undefined. In ES5, undefined can no longer be
-    // modified.
-
-    // window and document are passed through as local
-    // variables rather than as globals, because this (slightly)
-    // quickens the resolution process and can be more
-    // efficiently minified (especially when both are
-    // regularly referenced in your plugin).
 
     // Create the defaults once
     var pluginName = "jSprite",
@@ -40,16 +17,10 @@
                                         //    if false will not restart, if true will use timeTransition for a smooth restart
         };
 
-    // The actual plugin constructor
     function Plugin ( element, options ) {
         this.element = element;
         this.$el = $(this.element);
 
-        // jQuery has an extend method that merges the
-        // contents of two or more objects, storing the
-        // result in the first object. The first object
-        // is generally empty because we don't want to alter
-        // the default options for future instances of the plugin
         this.options = $.extend( {}, defaults, options) ;
 
         this._defaults = defaults;
@@ -168,7 +139,6 @@
         },
 
         init: function () {
-            // Place initialization logic here
             // You already have access to the DOM element and
             // the options via the instance, e.g. this.element
             // and this.options


### PR DESCRIPTION
Using jQuery lightweight plugin boilerplate.
https://github.com/jquery-boilerplate/jquery-patterns/blob/master/patterns/jquery.basic.plugin-boilerplate.js

Easier to write new functions, "this" contains the actual state of the sprite.

It's not necessary anymore to pass arguments all the time (sprite, settings, callback).

``` ruby
$('selector').jSprite({
            total: 14,
            timeTransition: 400,
            timeReload: false
        });
var sprite1 = $('selector').data('plugin_jSprite');
```

and now we can call plugn methods:

``` ruby
sprite1.restart();
```
